### PR TITLE
fix: skip bookmarks with empty name and url

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -85,10 +85,14 @@ def get_bookmarks(profile_path: Path) -> list[Bookmark]:
 
         cur.execute(
             """
-            SELECT moz_bookmarks.title, moz_places.url FROM moz_bookmarks
-            INNER JOIN moz_places ON moz_bookmarks.fk=moz_places.id
-            WHERE moz_bookmarks.fk is NOT NULL
-            AND moz_bookmarks.parent NOT IN (?)
+            SELECT moz_bookmarks.title, moz_places.url 
+            FROM moz_bookmarks
+                INNER JOIN moz_places ON moz_bookmarks.fk=moz_places.id
+            WHERE 1=1
+                AND moz_bookmarks.fk is NOT NULL
+                AND moz_bookmarks.title IS NOT NULL AND TRIM(moz_bookmarks.title) != ""
+                AND moz_places.url IS NOT NULL AND TRIM(moz_places.url) != ""
+                AND moz_bookmarks.parent NOT IN (?)
             """,
             ignored_folders,
         )


### PR DESCRIPTION
I got an error because one of the bookmark's name was empty.

This PR addresses this by skipping empty names and urls altogether.