### PR TITLE
feat: use last used profile

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,7 +41,7 @@ def get_profile_path() -> Path:
     profile.read(firefox_data_path / 'profiles.ini')
 
     last_profile_id = profile.get('General', 'Version', fallback='0')
-    profile_path = profile.get(f"Profile{last_profile_id}", 'Path', fallback=None)
+    profile_path = profile.get(f'Profile{last_profile_id}', 'Path', fallback=None)
     if profile_path and (firefox_data_path / profile_path / 'places.sqlite').exists():
         return firefox_data_path / profile_path
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,4 @@
 import configparser
-import re
 import shutil
 import sqlite3
 import tempfile


### PR DESCRIPTION
Adapted the code to use the last opened profile.

Given a profiles.ini (simplified a bit):

```ini
[General]
StartWithLastProfile=1
Version=1

[Profile0]
Name=dev-edition-default
IsRelative=1
Path=pe0cppkh.dev-edition-default-1717775821373

[Profile1]
Name=default
IsRelative=1
Path=4rkx4695.default
Default=1
```

Then reading `[General]`.`Version` will give the ID of the Profile.
Then reading `[Profile$ID]` will give the `Path` to the Profile.


@stevenxxiu I read your previous comment about using the devProfile as fallback (trying to find it by name).
I think that the solution of the PR is able to use the "correct" (as in "last used") profile.
I am using it currently with success (I have Firefox and the Developer both installed).